### PR TITLE
🎨 Implement 2 functionalities in js

### DIFF
--- a/decode/decryption/RichMsgHandle.proto
+++ b/decode/decryption/RichMsgHandle.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 message ForwardExtra {
-  int32 forward_orgId = 1;
+  int64 forward_orgId = 1;
   string forward_orgUin = 2;
   int32 forward_orgUinType = 3;
   string forward_orgUrl = 4;

--- a/decode/typeHandle/image/crc64.js
+++ b/decode/typeHandle/image/crc64.js
@@ -1,15 +1,15 @@
 // @ts-check
 
 const crc64_table = Array.from({ length: 256 }, () => 0n);
-for (let i = 0n; i < crc64_table.length; i += 1n) {
-    let bf = i;
+for (let i = 0; i < crc64_table.length; i += 1) {
+    let bf = BigInt(i);
     for (let j = 0; j < 8; j++) {
         if ((bf & 1n) != 0n) {
             bf = (bf >> 1n) ^ -7661587058870466123n;
         } else {
             bf >>= 1n;
         }
-        crc64_table[Number(i)] = bf;
+        crc64_table[i] = bf;
     }
 }
 
@@ -24,7 +24,14 @@ const crc64 = input => {
     return v.toString(16);
 };
 
-// Expected: `79e215c8f13ee1e7`
-// console.log(crc64('chatimg:73C393EEE6BA2A917FADD8F675985B8C'));
-
 module.exports = { crc64 };
+
+/** Only for test. If it comes out with error, just remove it */
+if (process.env.TEST) {
+    const assert = require('node:assert');
+    /** Only for test. If it comes out with error, just remove it */
+    assert.strictEqual(
+        crc64('chatimg:73C393EEE6BA2A917FADD8F675985B8C'),
+        '79e215c8f13ee1e7'
+    );
+}

--- a/decode/typeHandle/image/crc64.js
+++ b/decode/typeHandle/image/crc64.js
@@ -1,0 +1,30 @@
+// @ts-check
+
+const crc64_table = Array.from({ length: 256 }, () => 0n);
+for (let i = 0n; i < crc64_table.length; i += 1n) {
+    let bf = i;
+    for (let j = 0; j < 8; j++) {
+        if ((bf & 1n) != 0n) {
+            bf = (bf >> 1n) ^ -7661587058870466123n;
+        } else {
+            bf >>= 1n;
+        }
+        crc64_table[Number(i)] = bf;
+    }
+}
+
+/** @type {(input: string) => string} */
+const crc64 = input => {
+    let v = -1n;
+    for (let i = 0; i < input.length; i++) {
+        v =
+            crc64_table[Number((BigInt(input.charCodeAt(i)) ^ v) & 255n)] ^
+            (v >> 8n);
+    }
+    return v.toString(16);
+};
+
+// Expected: `79e215c8f13ee1e7`
+// console.log(crc64('chatimg:73C393EEE6BA2A917FADD8F675985B8C'));
+
+module.exports = { crc64 };


### PR DESCRIPTION
This PR contains:

## CRC64

Pure JS implement of the same algorithm in `crc64.py`.

Not fully tested yet. Test it before merging.

## Protobuf

One reason that js protobuf64 throws error is we've got the wrong protobuf file. In fact `forwardOrgId` could be out of range of `i32`. When use `i64` instead, there's no error again.

I've also discovered that the Java version has wrong definition. `version` should be at `15`, however, in Java version, `isReport` is at `15` instead of `16`.

Not fully tested yet. Test it before merging.